### PR TITLE
Draft 8 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ webhook-like scenarios where a provider needs to sign HTTP request messages befo
 subscribers need to verify incoming messages' signatures for authentication. Signatures can however also be applied to
 HTTP response messages for a client to verify on receipt.
 
-__*Disclaimer*__: Since the standard is currently in draft state, much like the standard itself, the libraries and its
-interfaces and implementations are subject to change.
+>__*Disclaimer*__
+>
+>Since the standard is currently in draft state, much like the standard itself, the libraries and its interfaces and
+>implementations are subject to change.
 
 ## Libraries and Nuget packages
 
@@ -32,7 +34,7 @@ them in `NSign.Client` at a later stage too.
 
 Below are some usage examples of the `NSign.*` libraries. Sample code will be added to the repository at a later time.
 
-### Validate signed requests in AspNetCore Server (.Net Core 3.1 and .Net 5.0)
+### Validate signed requests in AspNetCore Server (.Net Core 3.1 and .Net 5.0/6.0)
 
 The following excerpt of an ASP.NET Core's `Startup` class can be used to verify signatures on requests sent to `/webhooks`
 endpoints (and endpoints starting with `/webhooks/`). It also makes sure that signatures include the following request

--- a/common.props
+++ b/common.props
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <Version>0.2.0</Version>
+        <Version>0.8.0</Version>
 
         <Authors>Unify Square (a Unisys company)</Authors>
         <Product>NSign</Product>

--- a/src/NSign.Abstractions/Constants.cs
+++ b/src/NSign.Abstractions/Constants.cs
@@ -37,63 +37,63 @@
         }
 
         /// <summary>
-        /// Constants for HTTP message signing specialty components.
+        /// Constants for HTTP message signing derived components.
         /// </summary>
-        public static class SpecialtyComponents
+        public static class DerivedComponents
         {
             /// <summary>
-            /// The name of the specialty component holding signature parameters.
+            /// The name of the derived component holding signature parameters.
             /// </summary>
             public const string SignatureParams = "@signature-params";
 
             /// <summary>
-            /// The name of the specialty component holding the HTTP method of the message's associated request.
+            /// The name of the derived component holding the HTTP method of the message's associated request.
             /// </summary>
             public const string Method = "@method";
 
             /// <summary>
-            /// The name of the specialty component holding the full target URI of the message's associated request.
+            /// The name of the derived component holding the full target URI of the message's associated request.
             /// </summary>
             public const string TargetUri = "@target-uri";
 
             /// <summary>
-            /// The name of the specialty component holding the authority (host and port) of the message's associated request.
+            /// The name of the derived component holding the authority (host and port) of the message's associated request.
             /// </summary>
             public const string Authority = "@authority";
 
             /// <summary>
-            /// The name of the specialty component holding the schema of the message's associated request.
+            /// The name of the derived component holding the schema of the message's associated request.
             /// </summary>
             public const string Scheme = "@scheme";
 
             /// <summary>
-            /// The name of the specialty component holding the target (path and query) of the message's associated request.
+            /// The name of the derived component holding the target (path and query) of the message's associated request.
             /// </summary>
             public const string RequestTarget = "@request-target";
 
             /// <summary>
-            /// The name of the specialty component holding the path of the message's associated request.
+            /// The name of the derived component holding the path of the message's associated request.
             /// </summary>
             public const string Path = "@path";
 
             /// <summary>
-            /// The name of the specialty component holding the query of the message's associated request.
+            /// The name of the derived component holding the query of the message's associated request.
             /// </summary>
             public const string Query = "@query";
 
             /// <summary>
-            /// The name of the specialty component holding the dictionary-structured query parameters of the message's associated
+            /// The name of the derived component holding the dictionary-structured query parameters of the message's associated
             /// request.
             /// </summary>
             public const string QueryParams = "@query-params";
 
             /// <summary>
-            /// The name of the specialty component holding the status of the message's associated response.
+            /// The name of the derived component holding the status of the message's associated response.
             /// </summary>
             public const string Status = "@status";
 
             /// <summary>
-            /// The name of the specialty component holding the request-response signature binding.
+            /// The name of the derived component holding the request-response signature binding.
             /// </summary>
             public const string RequestResponse = "@request-response";
         }

--- a/src/NSign.Abstractions/Signatures/DerivedComponent.cs
+++ b/src/NSign.Abstractions/Signatures/DerivedComponent.cs
@@ -3,17 +3,17 @@
 namespace NSign.Signatures
 {
     /// <summary>
-    /// Represents a signature component based on a specialty field as per the standard.
+    /// Represents a signature component based on a derived field as per the standard.
     /// </summary>
-    public class SpecialtyComponent : SignatureComponent
+    public class DerivedComponent : SignatureComponent
     {
         /// <summary>
-        /// Initializes a new instance of SpecialtyComponent.
+        /// Initializes a new instance of DerivedComponent.
         /// </summary>
         /// <param name="name">
-        /// The name of the specialty component.
+        /// The name of the derived component.
         /// </param>
-        public SpecialtyComponent(string name) : base(SignatureComponentType.Specialty, ValidateNameOrThrow(name)) { }
+        public DerivedComponent(string name) : base(SignatureComponentType.Derived, ValidateNameOrThrow(name)) { }
 
         /// <inheritdoc/>
         public override void Accept(ISignatureComponentVisitor visitor)

--- a/src/NSign.Abstractions/Signatures/ISignatureComponentVisitor.cs
+++ b/src/NSign.Abstractions/Signatures/ISignatureComponentVisitor.cs
@@ -30,12 +30,12 @@
         void Visit(HttpHeaderDictionaryStructuredComponent httpHeaderDictionary);
 
         /// <summary>
-        /// Visits the given SpecialtyComponent.
+        /// Visits the given DerivedComponent.
         /// </summary>
-        /// <param name="specialty">
-        /// The SpecialtyComponent that is to be visited.
+        /// <param name="derived">
+        /// The DerivedComponent that is to be visited.
         /// </param>
-        void Visit(SpecialtyComponent specialty);
+        void Visit(DerivedComponent derived);
 
         /// <summary>
         /// Visits the given SignatureParamsComponent.

--- a/src/NSign.Abstractions/Signatures/QueryParamsComponent.cs
+++ b/src/NSign.Abstractions/Signatures/QueryParamsComponent.cs
@@ -4,10 +4,10 @@ using System.Diagnostics;
 namespace NSign.Signatures
 {
     /// <summary>
-    /// Represents the '@query-params' specialty signature component for a specific query parameter.
+    /// Represents the '@query-params' derived signature component for a specific query parameter.
     /// </summary>
     [DebuggerDisplay("Type={Type}, Component={ComponentName}, Name={Name}")]
-    public sealed class QueryParamsComponent : SpecialtyComponent, ISignatureComponentWithName, IEquatable<QueryParamsComponent>
+    public sealed class QueryParamsComponent : DerivedComponent, ISignatureComponentWithName, IEquatable<QueryParamsComponent>
     {
         /// <summary>
         /// Initializes a new instance of QueryParamsComponent.
@@ -15,7 +15,7 @@ namespace NSign.Signatures
         /// <param name="name">
         /// The name of the query parameter to use with this component.
         /// </param>
-        public QueryParamsComponent(string name) : base(Constants.SpecialtyComponents.QueryParams)
+        public QueryParamsComponent(string name) : base(Constants.DerivedComponents.QueryParams)
         {
             if (String.IsNullOrWhiteSpace(name))
             {

--- a/src/NSign.Abstractions/Signatures/RequestResponseComponent.cs
+++ b/src/NSign.Abstractions/Signatures/RequestResponseComponent.cs
@@ -4,11 +4,11 @@ using System.Diagnostics;
 namespace NSign.Signatures
 {
     /// <summary>
-    /// Represents the '@request-response' specialty signature component for a specific signature identified by its key.
+    /// Represents the '@request-response' derived signature component for a specific signature identified by its key.
     /// </summary>
     [DebuggerDisplay("Type={Type}, Component={ComponentName}, Key={Key}")]
     public sealed class RequestResponseComponent :
-        SpecialtyComponent, ISignatureComponentWithKey, IEquatable<RequestResponseComponent>
+        DerivedComponent, ISignatureComponentWithKey, IEquatable<RequestResponseComponent>
     {
         /// <summary>
         /// Initializes a new instance RequestResponseComponent.
@@ -16,7 +16,7 @@ namespace NSign.Signatures
         /// <param name="key">
         /// The key of the signature and signature input to correlate.
         /// </param>
-        public RequestResponseComponent(string key) : base(Constants.SpecialtyComponents.RequestResponse)
+        public RequestResponseComponent(string key) : base(Constants.DerivedComponents.RequestResponse)
         {
             if (String.IsNullOrWhiteSpace(key))
             {

--- a/src/NSign.Abstractions/Signatures/SignatureComponent.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureComponent.cs
@@ -12,44 +12,44 @@ namespace NSign.Signatures
         #region Consts
 
         /// <summary>
-        /// Represents the '@method' specialty component.
+        /// Represents the '@method' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Method = new SpecialtyComponent(Constants.SpecialtyComponents.Method);
+        public static readonly DerivedComponent Method = new DerivedComponent(Constants.DerivedComponents.Method);
 
         /// <summary>
-        /// Represents the '@target-uri' specialty component.
+        /// Represents the '@target-uri' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent RequestTargetUri = new SpecialtyComponent(Constants.SpecialtyComponents.TargetUri);
+        public static readonly DerivedComponent RequestTargetUri = new DerivedComponent(Constants.DerivedComponents.TargetUri);
 
         /// <summary>
-        /// Represents the '@authority' specialty component.
+        /// Represents the '@authority' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Authority = new SpecialtyComponent(Constants.SpecialtyComponents.Authority);
+        public static readonly DerivedComponent Authority = new DerivedComponent(Constants.DerivedComponents.Authority);
 
         /// <summary>
-        /// Represents the '@scheme' specialty component.
+        /// Represents the '@scheme' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Scheme = new SpecialtyComponent(Constants.SpecialtyComponents.Scheme);
+        public static readonly DerivedComponent Scheme = new DerivedComponent(Constants.DerivedComponents.Scheme);
 
         /// <summary>
-        /// Represents the '@request-target' specialty component.
+        /// Represents the '@request-target' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent RequestTarget = new SpecialtyComponent(Constants.SpecialtyComponents.RequestTarget);
+        public static readonly DerivedComponent RequestTarget = new DerivedComponent(Constants.DerivedComponents.RequestTarget);
 
         /// <summary>
-        /// Represents the '@path' specialty component.
+        /// Represents the '@path' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Path = new SpecialtyComponent(Constants.SpecialtyComponents.Path);
+        public static readonly DerivedComponent Path = new DerivedComponent(Constants.DerivedComponents.Path);
 
         /// <summary>
-        /// Represents the '@query' specialty component.
+        /// Represents the '@query' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Query = new SpecialtyComponent(Constants.SpecialtyComponents.Query);
+        public static readonly DerivedComponent Query = new DerivedComponent(Constants.DerivedComponents.Query);
 
         /// <summary>
-        /// Represents the '@status' specialty component.
+        /// Represents the '@status' derived component.
         /// </summary>
-        public static readonly SpecialtyComponent Status = new SpecialtyComponent(Constants.SpecialtyComponents.Status);
+        public static readonly DerivedComponent Status = new DerivedComponent(Constants.DerivedComponents.Status);
 
         /// <summary>
         /// Represents the 'Digest' HTTP header component.
@@ -81,7 +81,7 @@ namespace NSign.Signatures
         /// </param>
         protected SignatureComponent(SignatureComponentType type, string componentName)
         {
-            if (SignatureComponentType.HttpHeader != type && SignatureComponentType.Specialty != type)
+            if (SignatureComponentType.HttpHeader != type && SignatureComponentType.Derived != type)
             {
                 throw new ArgumentOutOfRangeException(nameof(type));
             }

--- a/src/NSign.Abstractions/Signatures/SignatureComponentType.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureComponentType.cs
@@ -16,8 +16,8 @@
         HttpHeader,
 
         /// <summary>
-        /// The component is a specialty field.
+        /// The component is a derived component.
         /// </summary>
-        Specialty,
+        Derived,
     }
 }

--- a/src/NSign.Abstractions/Signatures/SignatureInputParser.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureInputParser.cs
@@ -124,7 +124,7 @@ namespace NSign.Signatures
 
             if (componentNameSpan[0] == '@')
             {
-                AddSpecialtyComponent(componentName, componentParam);
+                AddDerivedComponent(componentName, componentParam);
             }
             else
             {
@@ -168,7 +168,7 @@ namespace NSign.Signatures
         }
 
         /// <summary>
-        /// Adds the given specialty component to the component list of the signatureParams.
+        /// Adds the given derived component to the component list of the signatureParams.
         /// </summary>
         /// <param name="componentName">
         /// The name of the component to add.
@@ -176,11 +176,11 @@ namespace NSign.Signatures
         /// <param name="componentParam">
         /// The optional parameter of the component to add.
         /// </param>
-        private void AddSpecialtyComponent(string componentName, KeyValuePair<string, string>? componentParam)
+        private void AddDerivedComponent(string componentName, KeyValuePair<string, string>? componentParam)
         {
             switch (componentName)
             {
-                case Constants.SpecialtyComponents.QueryParams:
+                case Constants.DerivedComponents.QueryParams:
                     if (!componentParam.HasValue ||
                         !StringComparer.Ordinal.Equals(Constants.ComponentParameters.Name, componentParam.Value.Key))
                     {
@@ -189,7 +189,7 @@ namespace NSign.Signatures
                     signatureParams.AddComponent(new QueryParamsComponent(componentParam.Value.Value));
                     break;
 
-                case Constants.SpecialtyComponents.RequestResponse:
+                case Constants.DerivedComponents.RequestResponse:
                     if (!componentParam.HasValue ||
                         !StringComparer.Ordinal.Equals(Constants.ComponentParameters.Key, componentParam.Value.Key))
                     {
@@ -199,36 +199,36 @@ namespace NSign.Signatures
                     break;
 
                 // Handle known cases without parameters too, so we can reuse existing components rather than creating more.
-                case Constants.SpecialtyComponents.Authority:
+                case Constants.DerivedComponents.Authority:
                     signatureParams.AddComponent(SignatureComponent.Authority);
                     break;
-                case Constants.SpecialtyComponents.Method:
+                case Constants.DerivedComponents.Method:
                     signatureParams.AddComponent(SignatureComponent.Method);
                     break;
-                case Constants.SpecialtyComponents.Path:
+                case Constants.DerivedComponents.Path:
                     signatureParams.AddComponent(SignatureComponent.Path);
                     break;
-                case Constants.SpecialtyComponents.Query:
+                case Constants.DerivedComponents.Query:
                     signatureParams.AddComponent(SignatureComponent.Query);
                     break;
-                case Constants.SpecialtyComponents.RequestTarget:
+                case Constants.DerivedComponents.RequestTarget:
                     signatureParams.AddComponent(SignatureComponent.RequestTarget);
                     break;
-                case Constants.SpecialtyComponents.Scheme:
+                case Constants.DerivedComponents.Scheme:
                     signatureParams.AddComponent(SignatureComponent.Scheme);
                     break;
-                case Constants.SpecialtyComponents.Status:
+                case Constants.DerivedComponents.Status:
                     signatureParams.AddComponent(SignatureComponent.Status);
                     break;
-                case Constants.SpecialtyComponents.TargetUri:
+                case Constants.DerivedComponents.TargetUri:
                     signatureParams.AddComponent(SignatureComponent.RequestTargetUri);
                     break;
 
-                case Constants.SpecialtyComponents.SignatureParams:
+                case Constants.DerivedComponents.SignatureParams:
                     throw new SignatureInputException("The @signature-params component is not allowed.");
 
                 default:
-                    signatureParams.AddComponent(new SpecialtyComponent(componentName));
+                    signatureParams.AddComponent(new DerivedComponent(componentName));
                     break;
             }
         }

--- a/src/NSign.Abstractions/Signatures/SignatureParamsComponent.cs
+++ b/src/NSign.Abstractions/Signatures/SignatureParamsComponent.cs
@@ -5,9 +5,9 @@ using System.Collections.ObjectModel;
 namespace NSign.Signatures
 {
     /// <summary>
-    /// Represents the '@signature-params' specialty signature component.
+    /// Represents the '@signature-params' derived signature component.
     /// </summary>
-    public sealed class SignatureParamsComponent : SpecialtyComponent
+    public sealed class SignatureParamsComponent : DerivedComponent
     {
         /// <summary>
         /// The Collection of SignatureComponent objects that should be included in the signature.
@@ -19,7 +19,7 @@ namespace NSign.Signatures
         /// <summary>
         /// Initializes a new instance of SignatureParamsComponent.
         /// </summary>
-        public SignatureParamsComponent() : base(Constants.SpecialtyComponents.SignatureParams)
+        public SignatureParamsComponent() : base(Constants.DerivedComponents.SignatureParams)
         {
             components = new Collection<SignatureComponent>();
         }
@@ -94,7 +94,7 @@ namespace NSign.Signatures
         public SignatureParamsComponent AddComponent(SignatureComponent component)
         {
             if (component is SignatureParamsComponent ||
-                component.ComponentName.Equals(Constants.SpecialtyComponents.SignatureParams))
+                component.ComponentName.Equals(Constants.DerivedComponents.SignatureParams))
             {
                 throw new InvalidOperationException("Cannot add a '@signature-params' component to a SignatureParamsComponent.");
             }

--- a/src/NSign.AspNetCore/AspNetCore/HttpRequestExtensions.Visitor.cs
+++ b/src/NSign.AspNetCore/AspNetCore/HttpRequestExtensions.Visitor.cs
@@ -93,29 +93,29 @@ namespace NSign.AspNetCore
             }
 
             /// <inheritdoc/>
-            public void Visit(SpecialtyComponent specialityComponent)
+            public void Visit(DerivedComponent derivedComponent)
             {
-                string value = specialityComponent.ComponentName switch
+                string value = derivedComponent.ComponentName switch
                 {
-                    Constants.SpecialtyComponents.SignatureParams => throw new NotSupportedException("The '@signature-params' component cannot be included explicitly."),
-                    Constants.SpecialtyComponents.Method => request.Method,
+                    Constants.DerivedComponents.SignatureParams => throw new NotSupportedException("The '@signature-params' component cannot be included explicitly."),
+                    Constants.DerivedComponents.Method => request.Method,
                     // TODO: Need to figure out a way to deal with reverse proxies changing paths, i.e. getting the original path/prefix.
-                    Constants.SpecialtyComponents.TargetUri => $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString}",
-                    Constants.SpecialtyComponents.Authority => request.Host.Value.ToLower(),
-                    Constants.SpecialtyComponents.Scheme => request.Scheme.ToLower(),
+                    Constants.DerivedComponents.TargetUri => $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString}",
+                    Constants.DerivedComponents.Authority => request.Host.Value.ToLower(),
+                    Constants.DerivedComponents.Scheme => request.Scheme.ToLower(),
                     // TODO: Need to figure out a way to deal with reverse proxies changing paths, i.e. getting the original path/prefix.
-                    Constants.SpecialtyComponents.RequestTarget => $"{request.PathBase}{request.Path}{request.QueryString}",
+                    Constants.DerivedComponents.RequestTarget => $"{request.PathBase}{request.Path}{request.QueryString}",
                     // TODO: Need to figure out a way to deal with reverse proxies changing paths, i.e. getting the original path/prefix.
-                    Constants.SpecialtyComponents.Path => $"{request.PathBase}{request.Path}",
-                    Constants.SpecialtyComponents.Query => request.QueryString.Value,
-                    Constants.SpecialtyComponents.QueryParams => throw new NotSupportedException("The '@query-params' component must have the 'name' parameter set."),
-                    Constants.SpecialtyComponents.Status => throw new NotSupportedException("The '@status' component cannot be included in request signatures."),
-                    Constants.SpecialtyComponents.RequestResponse => throw new NotSupportedException("The '@request-response' component must have the 'key' parameter set."),
+                    Constants.DerivedComponents.Path => $"{request.PathBase}{request.Path}",
+                    Constants.DerivedComponents.Query => request.QueryString.Value,
+                    Constants.DerivedComponents.QueryParams => throw new NotSupportedException("The '@query-params' component must have the 'name' parameter set."),
+                    Constants.DerivedComponents.Status => throw new NotSupportedException("The '@status' component cannot be included in request signatures."),
+                    Constants.DerivedComponents.RequestResponse => throw new NotSupportedException("The '@request-response' component must have the 'key' parameter set."),
 
-                    _ => throw new NotSupportedException($"Non-special signature component '{specialityComponent.ComponentName}' cannot be retrieved."),
+                    _ => throw new NotSupportedException($"Non-standard derived signature component '{derivedComponent.ComponentName}' cannot be retrieved."),
                 };
 
-                AddInput(specialityComponent, value);
+                AddInput(derivedComponent, value);
             }
 
             /// <inheritdoc/>

--- a/src/NSign.AspNetCore/AspNetCore/SignatureVerificationMiddleware.Context.cs
+++ b/src/NSign.AspNetCore/AspNetCore/SignatureVerificationMiddleware.Context.cs
@@ -28,8 +28,8 @@ namespace NSign.AspNetCore
             /// <remarks>
             /// This regex does NOT exactly parse according to RFC 8941, in particular when it comes down to commas in
             /// sf-string structured values; this however shouldn't be a problem here since the allowed values (HTTP
-            /// headers and predefined predefined specialty components, as well as parameters and their values as per the
-            /// standard) wouldn't use them.
+            /// headers and predefined derived components, as well as parameters and their values as per the standard)
+            /// wouldn't use them.
             /// </remarks>
             private static readonly Regex SignatureInputParser = new Regex(
                 "(?<=^|,\\s*) (\\w+) = ([^,]*) (?=,\\s*|$)",

--- a/src/NSign.Client/Client/HttpRequestMessageExtensions.InputBuildingVisitor.cs
+++ b/src/NSign.Client/Client/HttpRequestMessageExtensions.InputBuildingVisitor.cs
@@ -89,26 +89,26 @@ namespace NSign.Client
             }
 
             /// <inheritdoc/>
-            public override void Visit(SpecialtyComponent specialityComponent)
+            public override void Visit(DerivedComponent derived)
             {
-                string value = specialityComponent.ComponentName switch
+                string value = derived.ComponentName switch
                 {
-                    Constants.SpecialtyComponents.SignatureParams => throw new NotSupportedException("The '@signature-params' component cannot be included explicitly."),
-                    Constants.SpecialtyComponents.Method => request.Method.Method,
-                    Constants.SpecialtyComponents.TargetUri => request.RequestUri.OriginalString,
-                    Constants.SpecialtyComponents.Authority => request.RequestUri.Authority.ToLower(),
-                    Constants.SpecialtyComponents.Scheme => request.RequestUri.Scheme.ToLower(),
-                    Constants.SpecialtyComponents.RequestTarget => request.RequestUri.PathAndQuery,
-                    Constants.SpecialtyComponents.Path => request.RequestUri.AbsolutePath,
-                    Constants.SpecialtyComponents.Query => request.RequestUri.Query,
-                    Constants.SpecialtyComponents.QueryParams => throw new NotSupportedException("The '@query-params' component must have the 'name' parameter set."),
-                    Constants.SpecialtyComponents.Status => throw new NotSupportedException("The '@status' component cannot be included in request signatures."),
-                    Constants.SpecialtyComponents.RequestResponse => throw new NotSupportedException("The '@request-response' component must have the 'key' parameter set."),
+                    Constants.DerivedComponents.SignatureParams => throw new NotSupportedException("The '@signature-params' component cannot be included explicitly."),
+                    Constants.DerivedComponents.Method => request.Method.Method,
+                    Constants.DerivedComponents.TargetUri => request.RequestUri.OriginalString,
+                    Constants.DerivedComponents.Authority => request.RequestUri.Authority.ToLower(),
+                    Constants.DerivedComponents.Scheme => request.RequestUri.Scheme.ToLower(),
+                    Constants.DerivedComponents.RequestTarget => request.RequestUri.PathAndQuery,
+                    Constants.DerivedComponents.Path => request.RequestUri.AbsolutePath,
+                    Constants.DerivedComponents.Query => request.RequestUri.Query,
+                    Constants.DerivedComponents.QueryParams => throw new NotSupportedException("The '@query-params' component must have the 'name' parameter set."),
+                    Constants.DerivedComponents.Status => throw new NotSupportedException("The '@status' component cannot be included in request signatures."),
+                    Constants.DerivedComponents.RequestResponse => throw new NotSupportedException("The '@request-response' component must have the 'key' parameter set."),
 
-                    _ => throw new NotSupportedException($"Non-special signature component '{specialityComponent.ComponentName}' cannot be retrieved."),
+                    _ => throw new NotSupportedException($"Non-standard derived signature component '{derived.ComponentName}' cannot be retrieved."),
                 };
 
-                AddInput(specialityComponent, value);
+                AddInput(derived, value);
             }
 
             /// <inheritdoc/>

--- a/src/NSign.Client/Client/HttpRequestMessageExtensions.InputCheckingVisitor.cs
+++ b/src/NSign.Client/Client/HttpRequestMessageExtensions.InputCheckingVisitor.cs
@@ -55,30 +55,30 @@ namespace NSign.Client
             }
 
             /// <inheritdoc/>
-            public override void Visit(SpecialtyComponent specialityComponent)
+            public override void Visit(DerivedComponent derived)
             {
                 if (!Found)
                 {
                     return;
                 }
 
-                switch (specialityComponent.ComponentName)
+                switch (derived.ComponentName)
                 {
-                    case Constants.SpecialtyComponents.Method:
-                    case Constants.SpecialtyComponents.TargetUri:
-                    case Constants.SpecialtyComponents.Authority:
-                    case Constants.SpecialtyComponents.Scheme:
-                    case Constants.SpecialtyComponents.RequestTarget:
-                    case Constants.SpecialtyComponents.Path:
-                    case Constants.SpecialtyComponents.Query:
+                    case Constants.DerivedComponents.Method:
+                    case Constants.DerivedComponents.TargetUri:
+                    case Constants.DerivedComponents.Authority:
+                    case Constants.DerivedComponents.Scheme:
+                    case Constants.DerivedComponents.RequestTarget:
+                    case Constants.DerivedComponents.Path:
+                    case Constants.DerivedComponents.Query:
                         break;
 
-                    case Constants.SpecialtyComponents.SignatureParams:
-                    case Constants.SpecialtyComponents.QueryParams:
-                    case Constants.SpecialtyComponents.Status:
-                    case Constants.SpecialtyComponents.RequestResponse:
+                    case Constants.DerivedComponents.SignatureParams:
+                    case Constants.DerivedComponents.QueryParams:
+                    case Constants.DerivedComponents.Status:
+                    case Constants.DerivedComponents.RequestResponse:
                         throw new NotSupportedException(
-                            $"Speciality component '{specialityComponent.ComponentName}' must be added through the corresponding class.");
+                            $"Derived component '{derived.ComponentName}' must be added through the corresponding class.");
 
                     default:
                         Found = false;

--- a/src/NSign.Client/Client/HttpRequestMessageExtensions.cs
+++ b/src/NSign.Client/Client/HttpRequestMessageExtensions.cs
@@ -90,7 +90,7 @@ namespace NSign.Client
             public abstract void Visit(HttpHeaderDictionaryStructuredComponent httpHeaderDictionary);
 
             /// <inheritdoc/>
-            public abstract void Visit(SpecialtyComponent specialityComponent);
+            public abstract void Visit(DerivedComponent derived);
 
             /// <inheritdoc/>
             public abstract void Visit(SignatureParamsComponent signatureParams);

--- a/test/NSign.Abstractions.UnitTests/Signatures/DerivedComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/DerivedComponentTests.cs
@@ -4,15 +4,15 @@ using Xunit;
 
 namespace NSign.Signatures
 {
-    public sealed class SpecialtyComponentTests
+    public sealed class DerivedComponentTests
     {
-        private readonly SpecialtyComponent specialty = new SpecialtyComponent("@my-specialty");
+        private readonly DerivedComponent derived = new DerivedComponent("@my-derived");
 
         [Theory]
         [InlineData("header-component")]
         public void CtorThrowsForUnsupportedComponentName(string name)
         {
-            ArgumentOutOfRangeException aoorex = Assert.Throws<ArgumentOutOfRangeException>(() => new SpecialtyComponent(name));
+            ArgumentOutOfRangeException aoorex = Assert.Throws<ArgumentOutOfRangeException>(() => new DerivedComponent(name));
 
             Assert.Equal("name", aoorex.ParamName);
         }
@@ -22,21 +22,21 @@ namespace NSign.Signatures
         [InlineData("")]
         public void CtorThrowsForUnsupportedComponentNameFromBase(string name)
         {
-            ArgumentNullException aoorex = Assert.Throws<ArgumentNullException>(() => new SpecialtyComponent(name));
+            ArgumentNullException aoorex = Assert.Throws<ArgumentNullException>(() => new DerivedComponent(name));
 
             Assert.Equal("componentName", aoorex.ParamName);
         }
 
         [Fact]
-        public void ComponentTypeIsSpecialty()
+        public void ComponentTypeIsderived()
         {
-            Assert.Equal(SignatureComponentType.Specialty, specialty.Type);
+            Assert.Equal(SignatureComponentType.Derived, derived.Type);
         }
 
         [Fact]
         public void ComponentNameIsNormalized()
         {
-            Assert.Equal("@my-specialty", specialty.ComponentName);
+            Assert.Equal("@my-derived", derived.ComponentName);
         }
 
         [Fact]
@@ -44,11 +44,11 @@ namespace NSign.Signatures
         {
             Mock<ISignatureComponentVisitor> mockVisitor = new Mock<ISignatureComponentVisitor>(MockBehavior.Strict);
 
-            mockVisitor.Setup(v => v.Visit(It.Is<SpecialtyComponent>(c => c == specialty)));
+            mockVisitor.Setup(v => v.Visit(It.Is<DerivedComponent>(c => c == derived)));
 
-            specialty.Accept(mockVisitor.Object);
+            derived.Accept(mockVisitor.Object);
 
-            mockVisitor.Verify(v => v.Visit(It.IsAny<SpecialtyComponent>()), Times.Once);
+            mockVisitor.Verify(v => v.Visit(It.IsAny<DerivedComponent>()), Times.Once);
         }
     }
 }

--- a/test/NSign.Abstractions.UnitTests/Signatures/QueryParamsComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/QueryParamsComponentTests.cs
@@ -19,9 +19,9 @@ namespace NSign.Signatures
         }
 
         [Fact]
-        public void ComponentTypeIsSpecialty()
+        public void ComponentTypeIsDerived()
         {
-            Assert.Equal(SignatureComponentType.Specialty, queryParams.Type);
+            Assert.Equal(SignatureComponentType.Derived, queryParams.Type);
         }
 
         [Fact]

--- a/test/NSign.Abstractions.UnitTests/Signatures/RequestResponseComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/RequestResponseComponentTests.cs
@@ -19,9 +19,9 @@ namespace NSign.Signatures
         }
 
         [Fact]
-        public void ComponentTypeIsSpecialty()
+        public void ComponentTypeIsDerived()
         {
-            Assert.Equal(SignatureComponentType.Specialty, requestResponse.Type);
+            Assert.Equal(SignatureComponentType.Derived, requestResponse.Type);
         }
 
         [Fact]

--- a/test/NSign.Abstractions.UnitTests/Signatures/SignatureInputParserTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/SignatureInputParserTests.cs
@@ -48,7 +48,7 @@ namespace NSign.Signatures
                 (c) => Assert.Equal(new RequestResponseComponent("mySig"), c),
                 (c) => Assert.Equal(new HttpHeaderComponent("My-Header"), c),
                 (c) => Assert.Equal(new HttpHeaderDictionaryStructuredComponent("My-Dict-Header", "blah"), c),
-                (c) => Assert.Equal(new SpecialtyComponent("@extension"), c));
+                (c) => Assert.Equal(new DerivedComponent("@extension"), c));
 
             Assert.Equal(1234L, signatureParams.Created.Value.ToUnixTimeSeconds());
             Assert.Equal(-1534L, signatureParams.Expires.Value.ToUnixTimeSeconds());

--- a/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
+++ b/test/NSign.Abstractions.UnitTests/Signatures/SignatureParamsComponentTests.cs
@@ -25,9 +25,9 @@ namespace NSign.Signatures
         }
 
         [Fact]
-        public void ComponentTypeIsSpecialty()
+        public void ComponentTypeIsDerived()
         {
-            Assert.Equal(SignatureComponentType.Specialty, signatureParams.Type);
+            Assert.Equal(SignatureComponentType.Derived, signatureParams.Type);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace NSign.Signatures
             ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new SignatureParamsComponent()));
             Assert.Equal("Cannot add a '@signature-params' component to a SignatureParamsComponent.", ex.Message);
 
-            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new SpecialtyComponent("@signature-params")));
+            ex = Assert.Throws<InvalidOperationException>(() => signatureParams.AddComponent(new DerivedComponent("@signature-params")));
             Assert.Equal("Cannot add a '@signature-params' component to a SignatureParamsComponent.", ex.Message);
         }
     }

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
@@ -63,13 +63,13 @@ namespace NSign.AspNetCore
         [InlineData(@"(""x-dict"");expires=123", "\"x-dict\": a=a, c=d, a=b")]
         [InlineData(@"(""x-dict"";key=""a"");nonce=""123-abc""", "\"x-dict\";key=\"a\": b")]
         [InlineData(@"(""@method"");nonce=""555-def""", "\"@method\": POST")]
-        [InlineData(@"(""@target-uri"")", "\"@target-uri\": https://test:8443/sub/dir/endpoint/name/?a=b&a=c&x=")]
+        [InlineData(@"(""@target-uri"")", "\"@target-uri\": https://test:8443/sub/dir/endpoint/name/?a=b&A=C&x=")]
         [InlineData(@"(""@authority"");alg=""blah""", "\"@authority\": test:8443")]
         [InlineData(@"(""@scheme"")", "\"@scheme\": https")]
-        [InlineData(@"(""@request-target"")", "\"@request-target\": /sub/dir/endpoint/name/?a=b&a=c&x=")]
+        [InlineData(@"(""@request-target"")", "\"@request-target\": /sub/dir/endpoint/name/?a=b&A=C&x=")]
         [InlineData(@"(""@path"")", "\"@path\": /sub/dir/endpoint/name/")]
-        [InlineData(@"(""@query"")", "\"@query\": ?a=b&a=c&x=")]
-        [InlineData(@"(""@query-params"";name=""a"")", "\"@query-params\";name=\"a\": b\n\"@query-params\";name=\"a\": c")]
+        [InlineData(@"(""@query"")", "\"@query\": ?a=b&A=C&x=")]
+        [InlineData(@"(""@query-params"";name=""a"")", "\"@query-params\";name=\"a\": b\n\"@query-params\";name=\"a\": C")]
         [InlineData(@"(""@query-params"";name=""x"")", "\"@query-params\";name=\"x\": ")]
         public void VisitorProducesCorrectInputString(string rawInputSpec, string expectedInputMinusSignatureParams)
         {
@@ -81,7 +81,7 @@ namespace NSign.AspNetCore
             httpContext.Request.Host = new HostString("test:8443");
             httpContext.Request.PathBase = "/sub/dir";
             httpContext.Request.Path = "/endpoint/name/";
-            httpContext.Request.QueryString = new QueryString("?a=b&a=c&x=");
+            httpContext.Request.QueryString = new QueryString("?a=b&A=C&x=");
 
             SignatureInputSpec inputSpec = new SignatureInputSpec("test", rawInputSpec);
             byte[] input = httpContext.Request.GetSignatureInput(inputSpec);

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
@@ -51,7 +51,7 @@ namespace NSign.AspNetCore
         [InlineData(@"(""@status"")")]
         [InlineData(@"(""@request-response"";key=""sig1"")")]
         [InlineData(@"(""@blah"")")]
-        public void VisitorThrowsForUnsupportedSpecialtyComponents(string input)
+        public void VisitorThrowsForUnsupportedDerivedComponents(string input)
         {
             SignatureInputSpec inputSpec = new SignatureInputSpec("test", input);
             Assert.Throws<NotSupportedException>(() => httpContext.Request.GetSignatureInput(inputSpec));

--- a/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
+++ b/test/NSign.AspNetCore.UnitTests/AspNetCore/HttpRequestExtensionsTests.Visitor.cs
@@ -59,6 +59,7 @@ namespace NSign.AspNetCore
 
         [Theory]
         [InlineData(@"(""x-header"");created=123", "\"x-header\": the-value")]
+        [InlineData(@"(""x-empty"");created=123", "\"x-empty\": ")]
         [InlineData(@"(""x-dict"");expires=123", "\"x-dict\": a=a, c=d, a=b")]
         [InlineData(@"(""x-dict"";key=""a"");nonce=""123-abc""", "\"x-dict\";key=\"a\": b")]
         [InlineData(@"(""@method"");nonce=""555-def""", "\"@method\": POST")]
@@ -74,6 +75,7 @@ namespace NSign.AspNetCore
         {
             httpContext.Request.Headers.Add("x-header", "the-value");
             httpContext.Request.Headers.Add("x-dict", "a=a, c=d, a=b");
+            httpContext.Request.Headers.Add("x-empty", "");
             httpContext.Request.Method = "POST";
             httpContext.Request.Scheme = "https";
             httpContext.Request.Host = new HostString("test:8443");

--- a/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputBuildingVisitor.cs
+++ b/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputBuildingVisitor.cs
@@ -101,16 +101,16 @@ namespace NSign.Client
 
         [Theory]
         [InlineData("@method", "PUT")]
-        [InlineData("@target-uri", "https://some.host.local:8443/the/path/to/the/endpoint?my=param&another")]
+        [InlineData("@target-uri", "https://some.host.local:8443/the/path/to/the/endpoint?My=Param&another")]
         [InlineData("@authority", "some.host.local:8443")]
         [InlineData("@scheme", "https")]
-        [InlineData("@request-target", "/the/path/to/the/endpoint?my=param&another")]
+        [InlineData("@request-target", "/the/path/to/the/endpoint?My=Param&another")]
         [InlineData("@path", "/the/path/to/the/endpoint")]
-        [InlineData("@query", "?my=param&another")]
+        [InlineData("@query", "?My=Param&another")]
         public void GetSignatureInputGetsCorrectDerivedComponentValue(string name, string expectedValue)
         {
             request.Method = HttpMethod.Put;
-            request.RequestUri = new Uri("https://some.host.local:8443/the/path/to/the/endpoint?my=param&another");
+            request.RequestUri = new Uri("https://some.host.local:8443/the/path/to/the/endpoint?My=Param&another");
 
             SignatureInputSpec spec = new SignatureInputSpec("blah");
             spec.SignatureParameters.AddComponent(new DerivedComponent(name));

--- a/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputBuildingVisitor.cs
+++ b/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputBuildingVisitor.cs
@@ -78,10 +78,10 @@ namespace NSign.Client
         [InlineData("@status")]
         [InlineData("@request-response")]
         [InlineData("@blah")]
-        public void GetSignatureInputThrowsNotSupportedExceptionForUnsupportedSpecialtyComponents(string name)
+        public void GetSignatureInputThrowsNotSupportedExceptionForUnsupportedDerivedComponents(string name)
         {
             SignatureInputSpec spec = new SignatureInputSpec("foo");
-            spec.SignatureParameters.AddComponent(new SpecialtyComponent(name));
+            spec.SignatureParameters.AddComponent(new DerivedComponent(name));
             Assert.Throws<NotSupportedException>(() => request.GetSignatureInput(spec, out _));
         }
 
@@ -107,13 +107,13 @@ namespace NSign.Client
         [InlineData("@request-target", "/the/path/to/the/endpoint?my=param&another")]
         [InlineData("@path", "/the/path/to/the/endpoint")]
         [InlineData("@query", "?my=param&another")]
-        public void GetSignatureInputGetsCorrectSpecialtyComponentValue(string name, string expectedValue)
+        public void GetSignatureInputGetsCorrectDerivedComponentValue(string name, string expectedValue)
         {
             request.Method = HttpMethod.Put;
             request.RequestUri = new Uri("https://some.host.local:8443/the/path/to/the/endpoint?my=param&another");
 
             SignatureInputSpec spec = new SignatureInputSpec("blah");
-            spec.SignatureParameters.AddComponent(new SpecialtyComponent(name));
+            spec.SignatureParameters.AddComponent(new DerivedComponent(name));
             byte[] input = request.GetSignatureInput(spec, out string inputStr);
 
             Assert.Equal($"(\"{name}\")", inputStr);

--- a/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputCheckingVisitor.cs
+++ b/test/NSign.Client.UnitTests/Client/HttpRequestMessageExtensionsTests.InputCheckingVisitor.cs
@@ -62,7 +62,7 @@ namespace NSign.Client
             Assert.False(request.HasSignatureComponent(new QueryParamsComponent("non-param")));
 
             Assert.True(request.HasSignatureComponent(SignatureComponent.Query));
-            Assert.False(request.HasSignatureComponent(new SpecialtyComponent("@foo")));
+            Assert.False(request.HasSignatureComponent(new DerivedComponent("@foo")));
 
             Assert.True(request.HasSignatureComponent(new HttpHeaderComponent("content-length")));
             request.Content = null;
@@ -77,11 +77,11 @@ namespace NSign.Client
         [InlineData("@query-params")]
         [InlineData("@status")]
         [InlineData("@request-response")]
-        public void HasSignatureComponentThrowsNotSupportedExceptionForUnsupportedSpecialtyComponents(string name)
+        public void HasSignatureComponentThrowsNotSupportedExceptionForUnsupportedDerivedComponents(string name)
         {
             NotSupportedException ex = Assert.Throws<NotSupportedException>(
-                () => request.HasSignatureComponent(new SpecialtyComponent(name)));
-            Assert.Equal($"Speciality component '{name}' must be added through the corresponding class.", ex.Message);
+                () => request.HasSignatureComponent(new DerivedComponent(name)));
+            Assert.Equal($"Derived component '{name}' must be added through the corresponding class.", ex.Message);
         }
 
         [Fact]

--- a/test/NSign.Client.UnitTests/Client/SigningHandlerTests.cs
+++ b/test/NSign.Client.UnitTests/Client/SigningHandlerTests.cs
@@ -98,7 +98,7 @@ namespace NSign.Client
             options.WithOptionalComponent(SignatureComponent.ContentType);
             options.WithOptionalComponent(new HttpHeaderDictionaryStructuredComponent("missing-dict", "abc"));
             options.WithOptionalComponent(new QueryParamsComponent("missing"));
-            options.WithOptionalComponent(new SpecialtyComponent("@blah"));
+            options.WithOptionalComponent(new DerivedComponent("@blah"));
             options.UseUpdateSignatureParams = false;
 
             mockInnerHandler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
@@ -148,13 +148,13 @@ namespace NSign.Client
         [InlineData("@query-params", "The '@query-params' component must have the 'name' parameter set.")]
         [InlineData("@status", "The '@status' component cannot be included in request signatures.")]
         [InlineData("@request-response", "The '@request-response' component must have the 'key' parameter set.")]
-        [InlineData("@blah", "Non-special signature component '@blah' cannot be retrieved.")]
-        public async Task SendAsyncThrowsNotSupportedExceptionForSpecialtyComponentsNotSupportedOnRequests(string name, string expectedMessage)
+        [InlineData("@blah", "Non-standard derived signature component '@blah' cannot be retrieved.")]
+        public async Task SendAsyncThrowsNotSupportedExceptionForDerivedComponentsNotSupportedOnRequests(string name, string expectedMessage)
         {
             using HttpMessageInvoker invoker = new HttpMessageInvoker(handler);
 
             options.ComponentsToInclude.Clear();
-            options.WithMandatoryComponent(new SpecialtyComponent(name));
+            options.WithMandatoryComponent(new DerivedComponent(name));
             options.UseUpdateSignatureParams = false;
 
             NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(


### PR DESCRIPTION
These changes are mostly about the draft's changes from `specialty` components to `derived` components, plus some changes in unit tests to test some more scenarios explicitly, mostly around case-sentitivity.

In addition, versioning is (for now) adapted such that the minor version is a reference to the version of the draft. This way, all future `0.x` versions represent draft `x` of the standard.